### PR TITLE
html5: Add option to open Matrix chat at start of bbb

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -193,6 +193,19 @@ class Base extends Component {
               type: ACTIONS.SET_ID_CHAT_OPEN,
               value: PUBLIC_CHAT_ID,
             });
+          } else if (getFromUserSettings('bbb_show_public_chat_on_login', !Meteor.settings.public.matrix.startClosed)) {
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+              value: true,
+            });
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+              value: true,
+            });
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+              value: PANELS.MATRIX,
+            });
           } else {
             layoutContextDispatch({
               type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,


### PR DESCRIPTION
The chat panel had an option startClosed which you can set to false to start with an open chat panel.  Add the same option to the matrix chat.
