### PR TITLE
Keep Matrix chat persistent

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/matrix/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/matrix/component.jsx
@@ -37,6 +37,7 @@ const Matrix = ({
   intl,
   layoutContextDispatch,
   isResizing,
+  isVisible,
 }) => {
   const { isChrome } = browserInfo;
 
@@ -52,7 +53,11 @@ const Matrix = ({
   const matrixurl = `/riot-embedded/index.html?urlroomid=${matrixRoomID}&urlemail=${urlemail}&urlregcode=${urlregcode}`;
 
   return (
-    <Styled.Matrix data-test="matrix" isChrome={isChrome}>
+    <Styled.Matrix
+	data-test="matrix"
+	isChrome={isChrome}
+	style={{ visibility: isVisible ? 'visible' : 'hidden', }}
+     >
       <Header
         leftButtonProps={{
           onClick: () => {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -142,7 +142,7 @@ const SidebarContent = (props) => {
           isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES}
         />
       )}
-      {sidebarContentPanel === PANELS.MATRIX && <MatrixContainer />}
+      <MatrixContainer isVisible={sidebarContentPanel === PANELS.MATRIX}/>
       {sidebarContentPanel === PANELS.SHARED_NOTES && <NotesContainer />}
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
       {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}


### PR DESCRIPTION
When a user closes the Matrix chat, the iframe is closed and the session is killed, adding a loading delay every time. To avoid this, just hide the iframe instead of closing it.